### PR TITLE
Resolve auth issue from empty friendly name with default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-### Beta 0.6.0
+### Beta 0.6.1
 
 ## Features
 * Switch entities for each charging schedule allows enabling/disabling charge schedules.
@@ -74,6 +74,9 @@ data:
 Frankly depends on whether or not I sell my house (with the charger).
 
 ## Changelog
+
+### 0.6.1
+* Fix for empty friendly name causing authentication issue on integration setup. Fixes [#6](https://github.com/lwsrbrts/hassio-andersen-ev/issues/6)
 
 ### 0.6.0
 * First contribution from [@codeandr3w](https://github.com/codeandr3w) adds live grid power sensors.

--- a/custom_components/andersen_ev/konnect/client.py
+++ b/custom_components/andersen_ev/konnect/client.py
@@ -117,10 +117,12 @@ class KonnectClient:
         _LOGGER.debug("Found %s devices", len(response_body['devices']))
 
         for device in response_body['devices']:
+            # Use "Andersen" as default friendly name if not set or empty
+            friendly_name = device.get('friendlyName') or "Andersen"
             devices.append(KonnectDevice(
                 api = self,
                 device_id = device['id'],
-                friendly_name = device['friendlyName'],
+                friendly_name = friendly_name,
                 user_lock = device['userLock']))
 
         return devices

--- a/custom_components/andersen_ev/manifest.json
+++ b/custom_components/andersen_ev/manifest.json
@@ -8,6 +8,6 @@
   "requirements": ["warrant", "aiohttp"],
   "config_flow": true,
   "iot_class": "cloud_polling",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "icon": "mdi:ev-station"
 }


### PR DESCRIPTION
Modify client to use a default name when it's empty.