### PR TITLE
Refresh token on TransportQueryError with unauthenticated error message

### DIFF
--- a/custom_components/andersen_ev/konnect/graphql_client.py
+++ b/custom_components/andersen_ev/konnect/graphql_client.py
@@ -197,13 +197,18 @@ class GraphQLClient:
                 document, variable_values, wire_op_name, label
             )
         except TransportQueryError as err:
-            if not (
-                err.errors
-                and any(
-                    error.get("extensions", {}).get("code") == "UNAUTHENTICATED"
-                    for error in err.errors
+            unauthenticated = any(
+                (
+                    (
+                        error.get("extensions", {})
+                        if isinstance(error, dict)
+                        else getattr(error, "extensions", {}) or {}
+                    ).get("code")
+                    == "UNAUTHENTICATED"
                 )
-            ):
+                for error in (err.errors or [])
+            )
+            if not unauthenticated:
                 _LOGGER.warning("GraphQL errors in %s: %s", label, err.errors)
                 return None
             _LOGGER.info(

--- a/custom_components/andersen_ev/konnect/graphql_client.py
+++ b/custom_components/andersen_ev/konnect/graphql_client.py
@@ -192,32 +192,26 @@ class GraphQLClient:
             if err.code != 401:
                 _LOGGER.warning("Failed %s, HTTP status code: %s", label, err.code)
                 return None
-
-            _LOGGER.debug(
-                "Token expired during %s, refreshing and retrying",
-                label,
+            _LOGGER.debug("Token expired during %s, refreshing and retrying", label)
+            return await self._refresh_and_retry(
+                document, variable_values, wire_op_name, label
             )
-            try:
-                await self._refresh_and_reconnect()
-                return await self._session.execute(
-                    document,
-                    variable_values=variable_values,
-                    operation_name=wire_op_name,
-                )
-            except (
-                TransportServerError,
-                TransportQueryError,
-                OSError,
-            ) as retry_err:
-                _LOGGER.error(
-                    "Retry after token refresh failed for %s: %s",
-                    label,
-                    retry_err,
-                )
-                return None
         except TransportQueryError as err:
-            _LOGGER.warning("GraphQL errors in %s: %s", label, err.errors)
-            return None
+            if not (
+                err.errors
+                and any(
+                    error.get("extensions", {}).get("code") == "UNAUTHENTICATED"
+                    for error in err.errors
+                )
+            ):
+                _LOGGER.warning("GraphQL errors in %s: %s", label, err.errors)
+                return None
+            _LOGGER.info(
+                "Authentication error during %s, refreshing and retrying", label
+            )
+            return await self._refresh_and_retry(
+                document, variable_values, wire_op_name, label
+            )
         except OSError as err:
             _LOGGER.error("Error executing GraphQL %s: %s", label, err)
             return None
@@ -280,6 +274,29 @@ class GraphQLClient:
         _LOGGER.debug("setSolar response: %s", result)
         return True
 
+    async def _refresh_and_retry(
+        self,
+        document: DocumentNode,
+        variable_values: dict[str, Any] | None,
+        wire_op_name: str | None,
+        label: str,
+    ) -> dict[str, Any] | None:
+        """Refresh the token and retry the operation once."""
+        try:
+            await self._refresh_and_reconnect()
+            return await self._session.execute(
+                document,
+                variable_values=variable_values,
+                operation_name=wire_op_name,
+            )
+        except (TransportServerError, TransportQueryError, OSError) as retry_err:
+            _LOGGER.error(
+                "Retry after token refresh failed for %s: %s",
+                label,
+                retry_err,
+            )
+            return None
+
     # -- token refresh -----------------------------------------------------
 
     async def _refresh_and_reconnect(self) -> None:
@@ -311,7 +328,9 @@ class GraphQLClient:
     def _create_refresh_task(self) -> None:
         """Create a task for proactive token refresh, storing the reference."""
         self._refresh_task = asyncio.create_task(self._proactive_refresh())
-        self._refresh_task.add_done_callback(lambda _: setattr(self, "_refresh_task", None))
+        self._refresh_task.add_done_callback(
+            lambda _: setattr(self, "_refresh_task", None)
+        )
 
     async def _proactive_refresh(self) -> None:
         """Proactive refresh triggered by the scheduled timer."""


### PR DESCRIPTION
Previously token was only refreshed on a TransportServerError with 401 (unauthorized) response, but sometimes the andersen api triggers a TransportQueryError instead, with an UNAUTHENTICATED code. 

GraphQL errors in getDeviceStatus: [{'message': 'Context creation failed: Invalid/expired login token', 'extensions': {'code': 'UNAUTHENTICATED'}}]

Updated the code so such a response triggeres a token refresh too
